### PR TITLE
Fix some common errors or warnings:

### DIFF
--- a/src/command_queue.cc
+++ b/src/command_queue.cc
@@ -115,7 +115,7 @@ bool CommandQueue::WillAcceptCommand(int rank, int bankgroup, int bank) const {
 }
 
 bool CommandQueue::QueueEmpty() const {
-    for (const auto q : queues_) {
+    for (const auto &q : queues_) {
         if (!q.empty()) {
             return false;
         }

--- a/src/controller.cc
+++ b/src/controller.cc
@@ -11,22 +11,23 @@ Controller::Controller(int channel, const Config &config, const Timing &timing,
 #else
 Controller::Controller(int channel, const Config &config, const Timing &timing)
 #endif  // THERMAL
-    : channel_id_(channel),
+    : 
+#ifdef THERMAL
+      thermal_calc_(thermal_calc),
+#endif  // THERMAL
+      write_buffer_threshold_(8),
+      channel_id_(channel),
       clk_(0),
       config_(config),
       simple_stats_(config_, channel_id_),
       channel_state_(config, timing),
       cmd_queue_(channel_id_, config, channel_state_, simple_stats_),
       refresh_(config, channel_state_),
-#ifdef THERMAL
-      thermal_calc_(thermal_calc),
-#endif  // THERMAL
       is_unified_queue_(config.unified_queue),
       row_buf_policy_(config.row_buf_policy == "CLOSE_PAGE"
                           ? RowBufPolicy::CLOSE_PAGE
                           : RowBufPolicy::OPEN_PAGE),
       last_trans_clk_(0),
-      write_buffer_threshold_(8),
       write_draining_(0) {
     if (is_unified_queue_) {
         unified_queue_.reserve(config_.trans_queue_size);

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -21,7 +21,7 @@ class CPU {
     void ReadCallBack(uint64_t addr) { return; }
     void WriteCallBack(uint64_t addr) { return; }
     void PrintStats() { memory_system_.PrintStats(); }
-
+    virtual ~CPU() = default;
    protected:
     MemorySystem memory_system_;
     uint64_t clk_;

--- a/src/dram_system.cc
+++ b/src/dram_system.cc
@@ -173,7 +173,7 @@ bool JedecDRAMSystem::AddTransaction(uint64_t hex_addr, bool is_write,
     assert(ok);
     if (ok) {
         Transaction trans = Transaction(hex_addr, is_write, DataPtr);
-		Address addr = config_.AddressMapping(hex_addr);
+		// Address addr = config_.AddressMapping(hex_addr);
         // Send transaction to PIM Functional Simulator
         //  Performs physical memory RD/WR, bank mode change, set PIM register,
         //  execute PIM computation and write result to physical memory

--- a/src/transaction_generator.h
+++ b/src/transaction_generator.h
@@ -67,7 +67,7 @@ class TransactionGenerator {
         start_clk_ = 0;
         cnt_ = 0;
     }
-    ~TransactionGenerator() { delete(config_); }
+    virtual ~TransactionGenerator() { delete(config_); }
     // virtual void ClockTick() = 0;
     virtual void Initialize() = 0;
     virtual void SetData() = 0;


### PR DESCRIPTION
1. prevent copy in const auto for loop
2. reorder the init order in constructor to pervent possible wrong assignment.
3. the virtual class should have a virtual destructor function